### PR TITLE
feat: add mcp() hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+p6df module for Kubernetes: CLI tools (`kubectl`, `helm`, `minikube`, `k9s`),
+prompt integration, and MCP server (`kubernetes-mcp-server` via brew) for
+AI-driven cluster, pod, and resource management.
 
 ## Contributing
 
@@ -37,14 +39,15 @@ TODO: Add a short summary of this module.
 
 - `p6df::modules::kubernetes::ctx(ctx)`
   - Args:
-    - ctx - 
+    - ctx
 - `p6df::modules::kubernetes::deps()`
 - `p6df::modules::kubernetes::external::brew()`
+- `p6df::modules::kubernetes::mcp()`
 - `p6df::modules::kubernetes::minikube()`
 - `p6df::modules::kubernetes::minikube::start()`
 - `p6df::modules::kubernetes::ns(ns)`
   - Args:
-    - ns - 
+    - ns
 - `p6df::modules::kubernetes::off()`
 - `p6df::modules::kubernetes::on()`
 - `p6df::modules::kubernetes::prompt::mod()`

--- a/init.zsh
+++ b/init.zsh
@@ -198,3 +198,17 @@ p6df::modules::kubernetes::minikube::start() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: p6df::modules::kubernetes::mcp()
+#
+#>
+######################################################################
+p6df::modules::kubernetes::mcp() {
+
+  p6df::core::homebrew::cli::brew::install kubernetes-mcp-server
+
+  p6_return_void
+}


### PR DESCRIPTION
## Summary

- Add `mcp()` hook: installs `kubernetes-mcp-server` via brew for AI-driven Kubernetes cluster, pod, and resource management via MCP

## Test plan

- [ ] `p6df mcp` installs `kubernetes-mcp-server` via brew

🤖 Generated with [Claude Code](https://claude.com/claude-code)