### PR TITLE
feat: add kubernetes Claude skills to deps

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -11,6 +11,9 @@ p6df::modules::kubernetes::deps() {
     p6m7g8-dotfiles/p6df-zsh
     p6m7g8-dotfiles/p6kubernetes
     ohmyzsh/ohmyzsh:plugins/kubectl
+    ahmedasmar/devops-claude-skills:k8s-troubleshooter
+    geored/sre-skill
+    rohitg00/awesome-claude-code-toolkit:plugins/k8s-helper
   )
 }
 


### PR DESCRIPTION
## Summary
- Added `ahmedasmar/devops-claude-skills:k8s-troubleshooter` to dependencies in `init.zsh`
- Added `geored/sre-skill` to dependencies in `init.zsh`
- Added `rohitg00/awesome-claude-code-toolkit:plugins/k8s-helper` to dependencies in `init.zsh`

## Test plan
- [ ] Verify `init.zsh` loads without errors
- [ ] Confirm all three Kubernetes Claude skills are available after sourcing
- [ ] Verify k8s-troubleshooter, sre-skill, and k8s-helper skills function as expected
- [ ] Run existing test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)