### PR TITLE
chore: replace chmod 600 with p6_file_chmod in init.zsh

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -85,7 +85,7 @@ p6df::modules::kubernetes::prompt::mod() {
 p6df::modules::kubernetes::on() {
 
   KUBECONFIG="$HOME"/.kube/config
-  chmod 600 "$KUBECONFIG"
+  p6_file_chmod "600" "$KUBECONFIG"
   p6_env_export "KUBECONFIG" "$KUBECONFIG"
 
   p6_return_void


### PR DESCRIPTION
## Summary

- Replace `chmod 600 "$KUBECONFIG"` with `p6_file_chmod "600" "$KUBECONFIG"` in `init.zsh:88`

Note: `sudo chmod u+s` on lines 59-60 requires sudo and remains as-is.

## Test plan

- [ ] `p6df::modules::kubernetes::on` sets KUBECONFIG with correct permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)