### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -55,11 +55,11 @@ p6df::modules::kubernetes::vscodes() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::kubernetes::external::brew()
+# Function: p6df::modules::kubernetes::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::kubernetes::external::brew() {
+p6df::modules::kubernetes::external::brews() {
 
   p6df::core::homebrew::cli::brew::install buildkit
 


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly