### PR TITLE
fix(prompt): rename prompt::mod to prompt::context for kubernetes

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -84,11 +84,11 @@ p6df::modules::kubernetes::external::brews() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::kubernetes::prompt::mod()
+# Function: p6df::modules::kubernetes::prompt::context()
 #
 #>
 ######################################################################
-p6df::modules::kubernetes::prompt::mod() {
+p6df::modules::kubernetes::prompt::context() {
 
   p6_kubernetes_prompt_info
 }


### PR DESCRIPTION
## What
Renames `p6df::modules::kubernetes::prompt::mod()` to `p6df::modules::kubernetes::prompt::context()`.

## Why
Aligns the function name with its semantic purpose — it returns Kubernetes context info, not a generic module prompt.

## Test plan
- Reviewed diff manually
- Function body unchanged; rename only

## Dependencies
None