### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::kubernetes::deps()
-#
-#>
-######################################################################
 p6df::modules::kubernetes::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-zsh
@@ -18,13 +12,6 @@ p6df::modules::kubernetes::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::kubernetes::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_DIR
-#>
-######################################################################
 p6df::modules::kubernetes::home::symlinks() {
 
   p6_file_symlink "$P6_DFZ_SRC_DIR/ahmedasmar/devops-claude-skills/k8s-troubleshooter/skills"                                "$HOME/.claude/skills/k8s-troubleshooter"
@@ -36,28 +23,6 @@ p6df::modules::kubernetes::home::symlinks() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::kubernetes::vscodes()
-#
-#>
-######################################################################
-p6df::modules::kubernetes::vscodes() {
-
-  # kubernetes
-  p6df::modules::vscode::extension::install ms-kubernetes-tools.vscode-kubernetes-tools
-  p6df::modules::vscode::extension::install ipedrazas.kubernetes-snippets
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::kubernetes::external::brews()
-#
-#>
 ######################################################################
 p6df::modules::kubernetes::external::brews() {
 
@@ -81,6 +46,51 @@ p6df::modules::kubernetes::external::brews() {
   p6_return_void
 }
 
+######################################################################
+p6df::modules::kubernetes::mcp() {
+
+  p6df::core::homebrew::cli::brew::install kubernetes-mcp-server
+
+  p6df::modules::anthropic::mcp::server::add "kubernetes" "kubernetes-mcp-server"
+  p6df::modules::openai::mcp::server::add "kubernetes" "kubernetes-mcp-server"
+
+  p6_return_void
+}
+######################################################################
+p6df::modules::kubernetes::vscodes() {
+
+  # kubernetes
+  p6df::modules::vscode::extension::install ms-kubernetes-tools.vscode-kubernetes-tools
+  p6df::modules::vscode::extension::install ipedrazas.kubernetes-snippets
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::kubernetes::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::kubernetes::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::kubernetes::vscodes()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::kubernetes::external::brews()
+#
+#>
 ######################################################################
 #<
 #
@@ -227,13 +237,3 @@ p6df::modules::kubernetes::minikube::start() {
 # Function: p6df::modules::kubernetes::mcp()
 #
 #>
-######################################################################
-p6df::modules::kubernetes::mcp() {
-
-  p6df::core::homebrew::cli::brew::install kubernetes-mcp-server
-
-  p6df::modules::anthropic::mcp::server::add "kubernetes" "kubernetes-mcp-server"
-  p6df::modules::openai::mcp::server::add "kubernetes" "kubernetes-mcp-server"
-
-  p6_return_void
-}

--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::kubernetes::deps()
+#
+#>
+######################################################################
 p6df::modules::kubernetes::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-zsh
@@ -12,6 +18,13 @@ p6df::modules::kubernetes::deps() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::kubernetes::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR
+#>
+######################################################################
 p6df::modules::kubernetes::home::symlinks() {
 
   p6_file_symlink "$P6_DFZ_SRC_DIR/ahmedasmar/devops-claude-skills/k8s-troubleshooter/skills"                                "$HOME/.claude/skills/k8s-troubleshooter"
@@ -23,6 +36,12 @@ p6df::modules::kubernetes::home::symlinks() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::kubernetes::external::brews()
+#
+#>
 ######################################################################
 p6df::modules::kubernetes::external::brews() {
 
@@ -47,6 +66,12 @@ p6df::modules::kubernetes::external::brews() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::kubernetes::mcp()
+#
+#>
+######################################################################
 p6df::modules::kubernetes::mcp() {
 
   p6df::core::homebrew::cli::brew::install kubernetes-mcp-server
@@ -57,6 +82,12 @@ p6df::modules::kubernetes::mcp() {
   p6_return_void
 }
 ######################################################################
+#<
+#
+# Function: p6df::modules::kubernetes::vscodes()
+#
+#>
+######################################################################
 p6df::modules::kubernetes::vscodes() {
 
   # kubernetes
@@ -66,31 +97,6 @@ p6df::modules::kubernetes::vscodes() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::kubernetes::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::kubernetes::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::kubernetes::vscodes()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::kubernetes::external::brews()
-#
-#>
 ######################################################################
 #<
 #
@@ -231,9 +237,3 @@ p6df::modules::kubernetes::minikube::start() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::kubernetes::mcp()
-#
-#>


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None